### PR TITLE
Add an issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+### Goals
+
+Describe the overall goals of the AGP here, preferably in a list of a few concise bullet points.
+
+- Goal 1
+- Goal 2
+- Goal 3
+
+### Description
+
+Go into detail here. Explain what the AGP does and why.
+
+### Uncertainties
+
+Describe some unsolved problems or points of discussion, if there are any.


### PR DESCRIPTION
Adds a very basic issue template to standardize the information that should be included in an AGP.

The issue title and issue # will probably suffice for a preamble, instead of manually typing that out like in EIPs and ERCs.